### PR TITLE
レビュー④ 3-3-1 新規登録機能を実装する

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,13 @@
+class TasksController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,6 +6,7 @@ class TasksController < ApplicationController
   end
 
   def new
+    @task = Task.new
   end
 
   def edit

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,9 +1,7 @@
 class TasksController < ApplicationController
-  def index
-  end
+  def index; end
 
-  def show
-  end
+  def show; end
 
   def new
     @task = Task.new
@@ -13,10 +11,9 @@ class TasksController < ApplicationController
     task = Task.new(task_params)
     task.save!
     redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
-  end  
-
-  def edit
   end
+
+  def edit; end
 
   private
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,6 +9,18 @@ class TasksController < ApplicationController
     @task = Task.new
   end
 
+  def create
+    task = Task.new(task_params)
+    task.save!
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+  end  
+
   def edit
+  end
+
+  private
+
+  def task_params
+    params.require(:task).permit(:name, :description)
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,0 +1,2 @@
+module TasksHelper
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,4 +9,7 @@ html
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_importmap_tags
   body
-    = yield
+    .container
+      - if flash.notice.present?
+        .alert.alert-success= flash.notice
+      = yield

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Tasks#edit
+p Find me in app/views/tasks/edit.html.slim

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,2 +1,3 @@
-h1 Tasks#index
-p Find me in app/views/tasks/index.html.slim
+h1 タスク一覧
+
+= link_to '新規登録', new_task_path, class: 'btn btn-primary'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,0 +1,2 @@
+h1 Tasks#index
+p Find me in app/views/tasks/index.html.slim

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,0 +1,2 @@
+h1 Tasks#new
+p Find me in app/views/tasks/new.html.slim

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -11,4 +11,3 @@ h1 タスクの新規登録
     = f.label :description
     = f.text_field :description, rows: 5, class: 'form-control', id: 'task_description'
   = f.submit nil, class: 'btn btn-primary'
-  

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -11,3 +11,4 @@ h1 タスクの新規登録
     = f.label :description
     = f.text_field :description, rows: 5, class: 'form-control', id: 'task_description'
   = f.submit nil, class: 'btn btn-primary'
+  

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,2 +1,13 @@
-h1 Tasks#new
-p Find me in app/views/tasks/new.html.slim
+h1 タスクの新規登録
+
+.nav.justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local:true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_field :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -1,0 +1,2 @@
+h1 Tasks#show
+p Find me in app/views/tasks/show.html.slim

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,15 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      task: タスク
+    attributes:
+      task:
+        id: ID
+        name: 名称
+        description: 詳しい説明
+        created_at: 登録日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,4 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get 'up' => 'rails/health#show', as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  root to: 'tasks#index'
+  resources :tasks
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class TasksControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get tasks_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get tasks_show_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get tasks_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get tasks_edit_url
+    assert_response :success
+  end
+end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,22 +1,22 @@
-require "test_helper"
+require 'test_helper'
 
 class TasksControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test 'should get index' do
     get tasks_index_url
     assert_response :success
   end
 
-  test "should get show" do
+  test 'should get show' do
     get tasks_show_url
     assert_response :success
   end
 
-  test "should get new" do
+  test 'should get new' do
     get tasks_new_url
     assert_response :success
   end
 
-  test "should get edit" do
+  test 'should get edit' do
     get tasks_edit_url
     assert_response :success
   end


### PR DESCRIPTION
レビュー④ 3-3-1 新規登録機能を実装する　が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
・tasksコントローラー作成
・トップページを作成し、新規登録ボタンから新規登録画面に遷移する
・新規登録のためのアクションを追記
・新規登録画面のビューを作成
・「登録ボタン」を押下するとデータ保存し、
　トップページに戻る(フラッシュで『タスク「test3」を登録しました。』と表示)

## 実行結果
新規登録画面
![image](https://github.com/ChisatoMatoba/taskleaf_matoba/assets/149556430/4d8a1d28-175d-4cbc-a384-e3e869f43679)

「登録する」ボタン押下後
![282380471-10a484b5-f535-4a98-8a0d-086062cf6c91](https://github.com/ChisatoMatoba/taskleaf_matoba/assets/149556430/06d8b2fe-2f2d-40d5-8a8d-95440368964b)

