### PR TITLE
レビュー⑥ 3-3-5 削除機能を実装する

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -20,7 +20,15 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
   end
 
-  def edit; end
+  def edit
+    @task = Task.find(params[:id])
+  end
+
+  def update
+    task = Task.find(params[:id])
+    task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
+  end
 
   private
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -24,10 +24,18 @@ class TasksController < ApplicationController
     @task = Task.find(params[:id])
   end
 
+  # 更新
   def update
     task = Task.find(params[:id])
     task.update!(task_params)
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
+  end
+
+  # 削除
+  def destroy
+    task = Task.find(params[:id])
+    task.destroy
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -24,14 +24,12 @@ class TasksController < ApplicationController
     @task = Task.find(params[:id])
   end
 
-  # 更新
   def update
     task = Task.find(params[:id])
     task.update!(task_params)
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
-  # 削除
   def destroy
     task = Task.find(params[:id])
     task.destroy

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,4 +1,4 @@
-= form_with model: task, local:true do |f|
+= form_with model: task, local: true do |f|
   .form-group
     = f.label :name
     = f.text_field :name, class: 'form-control', id: 'task_name'

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,8 @@
+= form_with model: task, local:true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_field :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,2 +1,13 @@
-h1 Tasks#edit
-p Find me in app/views/tasks/edit.html.slim
+h1 タスクの編集
+
+.nav.justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -3,11 +3,4 @@ h1 タスクの編集
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -16,3 +16,4 @@ table.table.table-hover
         td= task.created_at
         td
           = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'
+          = link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -8,8 +8,11 @@ table.table.table-hover
     tr
       th= Task.human_attribute_name(:name)
       th= Task.human_attribute_name(:created_at)
+      th
   tboby
     - @tasks.each do |task|
       tr
         td= link_to task.name, task_path(task)
         td= task.created_at
+        td
+          = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -16,4 +16,4 @@ table.table.table-hover
         td= task.created_at
         td
           = link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'
-          = link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'
+          = link_to '削除', task, data: { turbo_method: :delete, turbo_confirm: "タスク「#{task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,11 +3,4 @@ h1 タスクの新規登録
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local:true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_field :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -20,3 +20,4 @@ table.table.table-hover
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
 = link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
+= link_to '削除', @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -19,3 +19,4 @@ table.table.table-hover
     tr
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
+= link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -20,9 +20,4 @@ table.table.table-hover
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
 = link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
-
-/
-= link_to '削除', @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'
-
-
-= link_to "削除", task_path(@task.id), data: { turbo_method: :delete, confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'
+= link_to '削除', @task, data: { turbo_method: :delete, turbo_confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -20,4 +20,9 @@ table.table.table-hover
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
 = link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
+
+/
 = link_to '削除', @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'
+
+
+= link_to "削除", task_path(@task.id), data: { turbo_method: :delete, confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'


### PR DESCRIPTION
レビュー⑥ 3-3-5 削除機能を実装する　が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
・編集機能の実装(一覧表示画面、詳細画面から)
・新規登録画面と編集画面の共通部分をパーシャルテンプレートで共通化
・削除機能の実装(一覧表示画面、詳細画面から)

## テキストと異なる点
テキストとは違い、rails 7で実装したため、標準構成に入ったturboを用いて記述するように変更した。index.html.slimとshow.html.slimにて本対応を実施。
例：
テキスト(show.html.slim)：動かない
`= link_to '削除', @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'`
修正後：動くことを確認
`= link_to "削除", @task, data: { turbo_method: :delete, turbo_confirm: "タスク「#{@task.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'`

## 実行結果
一覧画面→編集
[![Image from Gyazo](https://i.gyazo.com/548f089adcf1f5467785b836297c82e7.gif)](https://gyazo.com/548f089adcf1f5467785b836297c82e7)

詳細画面→編集
[![Image from Gyazo](https://i.gyazo.com/783433ad1d9cac09ee487b2202abc953.gif)](https://gyazo.com/783433ad1d9cac09ee487b2202abc953)

一覧画面から削除
[![Image from Gyazo](https://i.gyazo.com/d0a08fa32bae03e5faa09cebb9be917f.gif)](https://gyazo.com/d0a08fa32bae03e5faa09cebb9be917f)

詳細画面から削除
[![Image from Gyazo](https://i.gyazo.com/5c224116c8e598d78218afbcca17d6f4.gif)](https://gyazo.com/5c224116c8e598d78218afbcca17d6f4)