### PR TITLE
レビュー⑦ 4-4 モデルの状態を自動的に制御する「コールバック」

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,9 +15,13 @@ class TasksController < ApplicationController
   end
 
   def create
-    task = Task.new(task_params)
-    task.save!
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+    @task = Task.new(task_params)
+
+    if @task.save
+      redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"
+    else
+      render :new
+    end
   end
 
   def edit

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -20,7 +20,7 @@ class TasksController < ApplicationController
     if @task.save
       redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  validates :name, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,6 +2,7 @@
 
 # Represents task data as an ActiveRecord model.
 class Task < ApplicationRecord
+  before_validation :set_nameless_name
   validates :name, presence: true, length: { maximum: 30 }
   validate :validate_name_not_including_comma
 
@@ -9,5 +10,9 @@ class Task < ApplicationRecord
 
   def validate_name_not_including_comma
     errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')
+  end
+
+  def set_nameless_name
+    self.name = '名前なし' if name.blank?
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,4 +3,11 @@
 # Represents task data as an ActiveRecord model.
 class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
+  validate :validate_name_not_including_comma
+
+  private
+
+  def validate_name_not_including_comma
+    errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Represents task data as an ActiveRecord model.
 class Task < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 30 }
 end

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,8 +1,13 @@
+- if task.errors.present?
+  ul#error_explanation
+    - task.errors.full_messages.each do |message|
+      li= message
+
 = form_with model: task, local: true do |f|
   .form-group
     = f.label :name
     = f.text_field :name, class: 'form-control', id: 'task_name'
   .form-group
     = f.label :description
-    = f.text_field :description, rows: 5, class: 'form-control', id: 'task_description'
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
   = f.submit nil, class: 'btn btn-primary'


### PR DESCRIPTION
レビュー⑦ 4-4 モデルの状態を自動的に制御する「コールバック」が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
(1) modelの検証
以下のバリデーションを設定
　名称：必須、30字以内、カンマを含めてはいけない
(2) 名称が空欄の場合、コールバックを使って「名前なし」を自動で命名

## テキストと異なる点
バリデーションエラー表示の際、`render :new`で返すときに `status: :unprocessable_entity`を付与するように変更。
rails7標準のturboではrenderで適切なステータスコードを選択しなければならないため。
 ```Ruby
 def create
    @task = Task.new(task_params)

    if @task.save
      redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"
    else
      render :new, status: :unprocessable_entity
    end
  end
```

## 実行結果
(1) modelの検証
名称が空欄　※[自作バリデーションcommit](https://github.com/ChisatoMatoba/taskleaf_matoba/commit/125c6fc7258cefc9af33b2912b4c75d60c7fc5fd)の段階での動作
[![Image from Gyazo](https://i.gyazo.com/f47d699543d57dd149e14fbed838fdff.gif)](https://gyazo.com/f47d699543d57dd149e14fbed838fdff)
名称が30文字以上
[![Image from Gyazo](https://i.gyazo.com/4133b3dd4c823fa3d94aeba8c9b23e13.gif)](https://gyazo.com/4133b3dd4c823fa3d94aeba8c9b23e13)
名称にカンマが入っている
[![Image from Gyazo](https://i.gyazo.com/dcc3d0fa077948ec4d8bbaf91c71966e.gif)](https://gyazo.com/dcc3d0fa077948ec4d8bbaf91c71966e)

(2) 名称が空欄の場合、コールバックを使って「名前なし」を自動で命名
[![Image from Gyazo](https://i.gyazo.com/fadd5d67d441c2e4346b9994e3921834.gif)](https://gyazo.com/fadd5d67d441c2e4346b9994e3921834)