### PR TITLE
レビュー⑧ 4-5-10~ ログインユーザーのみ操作可能などの機能制限

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,4 @@ AllCops:
  Exclude:
    - "config/**/*"
    - "bin/*"
+   - "db/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'jbuilder'
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[windows jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'jbuilder'
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-gem "bcrypt", "~> 3.1.7"
+gem 'bcrypt', '~> 3.1.7'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[windows jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     autoprefixer-rails (10.4.15.0)
       execjs (~> 2)
     base64 (0.2.0)
+    bcrypt (3.1.19)
     bigdecimal (3.1.4)
     bindex (0.8.1)
     bootsnap (1.17.0)
@@ -292,6 +293,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   bootstrap
   capybara

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,5 @@
 class Admin::UsersController < ApplicationController
+  before_action :require_admin
 
   def index
     @users = User.all
@@ -46,5 +47,9 @@ class Admin::UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
+
+  def require_admin
+    redirect_to root_path unless current_user.admin?
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,17 @@
 class Admin::UsersController < ApplicationController
+
+  def index
+    @users = User.all
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
   def new
     @user = User.new
   end
@@ -13,13 +26,20 @@ class Admin::UsersController < ApplicationController
     end
   end
 
-  def edit
+  def update
+    @user = User.find(params[:id])
+
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), notice: "ユーザ「#{@user.name}」を更新しました。"
+    else
+      render :new
+    end
   end
 
-  def show
-  end
-
-  def index
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to admin_users_url, notice: "ユーザ「#{@user.name}」を削除しました。"
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,55 +1,60 @@
-class Admin::UsersController < ApplicationController
-  before_action :require_admin
+# frozen_string_literal: true
 
-  def index
-    @users = User.all
-  end
+module Admin
+  # class Admin::UsersController
+  class UsersController < ApplicationController
+    before_action :require_admin
 
-  def show
-    @user = User.find(params[:id])
-  end
-
-  def edit
-    @user = User.find(params[:id])
-  end
-
-  def new
-    @user = User.new
-  end
-
-  def create
-    @user = User.new(user_params)
-
-    if @user.save
-      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を登録しました。"
-    else
-      render :new, status: :unprocessable_entity
+    def index
+      @users = User.all
     end
-  end
 
-  def update
-    @user = User.find(params[:id])
-
-    if @user.update(user_params)
-      redirect_to admin_user_path(@user), notice: "ユーザ「#{@user.name}」を更新しました。"
-    else
-      render :new
+    def show
+      @user = User.find(params[:id])
     end
-  end
 
-  def destroy
-    @user = User.find(params[:id])
-    @user.destroy
-    redirect_to admin_users_url, notice: "ユーザ「#{@user.name}」を削除しました。"
-  end
+    def edit
+      @user = User.find(params[:id])
+    end
 
-  private
+    def new
+      @user = User.new
+    end
 
-  def user_params
-    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
-  end
+    def create
+      @user = User.new(user_params)
 
-  def require_admin
-    redirect_to root_path unless current_user.admin?
+      if @user.save
+        redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を登録しました。"
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      @user = User.find(params[:id])
+
+      if @user.update(user_params)
+        redirect_to admin_user_path(@user), notice: "ユーザ「#{@user.name}」を更新しました。"
+      else
+        render :new
+      end
+    end
+
+    def destroy
+      @user = User.find(params[:id])
+      @user.destroy
+      redirect_to admin_users_url, notice: "ユーザ「#{@user.name}」を削除しました。"
+    end
+
+    private
+
+    def user_params
+      params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+    end
+
+    def require_admin
+      redirect_to root_path unless current_user.admin?
+    end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,30 @@
+class Admin::UsersController < ApplicationController
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を登録しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def show
+  end
+
+  def index
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  helper_method :current_user
+
+  private
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,15 @@
 
 class ApplicationController < ActionController::Base
   helper_method :current_user
+  before_action :login_required
 
   private
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def login_required
+    redirect_to login_path unless current_user
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# class ApplicationController
 class ApplicationController < ActionController::Base
   helper_method :current_user
   before_action :login_required

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# class SessionsController
 class SessionsController < ApplicationController
   skip_before_action :login_required
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,20 @@
+class SessionsController < ApplicationController
+  def new; end
+
+  def create
+    user = User.find_by(email: session_params[:email])
+
+    if user&.authenticate(session_params[:password])
+      session[:user_id] = user.id
+      redirect_to root_path, notice: 'ログインしました。'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email, :password)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :login_required
+
   def new; end
 
   def create
@@ -10,6 +12,11 @@ class SessionsController < ApplicationController
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    reset_session
+    redirect_to root_path, notice: 'ログアウトしました。'
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,11 +3,11 @@
 # TasksController handles the management of tasks in the application.
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    @tasks = current_user.tasks
   end
 
   def show
-    @task = Task.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
   end
 
   def new
@@ -15,7 +15,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    @task = current_user.tasks.new(task_params)
 
     if @task.save
       redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"
@@ -25,17 +25,17 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = Task.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
   end
 
   def update
-    task = Task.find(params[:id])
+    task = current_user.tasks.find(params[:id])
     task.update!(task_params)
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
   def destroy
-    task = Task.find(params[:id])
+    task = current_user.tasks.find(params[:id])
     task.destroy
     redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
   end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,2 +1,8 @@
-module Admin::UsersHelper
+# frozen_string_literal: true
+
+# module Admin
+module Admin
+  # module Admin::UsersHelper
+  module UsersHelper
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# module SessionsHelper
 module SessionsHelper
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,7 +2,6 @@
 
 # Represents task data as an ActiveRecord model.
 class Task < ApplicationRecord
-  before_validation :set_nameless_name
   validates :name, presence: true, length: { maximum: 30 }
   validate :validate_name_not_including_comma
 
@@ -10,9 +9,5 @@ class Task < ApplicationRecord
 
   def validate_name_not_including_comma
     errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')
-  end
-
-  def set_nameless_name
-    self.name = '名前なし' if name.blank?
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,6 +5,8 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
   validate :validate_name_not_including_comma
 
+  belongs_to :user
+
   private
 
   def validate_name_not_including_comma

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
+
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  has_secure_password
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
+
+  has_many :tasks
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# class User
 class User < ApplicationRecord
   has_secure_password
 

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,0 +1,23 @@
+- if user.errors.present?
+  ul#error_explanation
+    - user.errors.full_messages.each do |message|
+      li= message
+
+= form_with model: [:admin, user], local: true do |f|
+  .form-group
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .form-group
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control'
+  .form-check
+    = f.label :admin, class: 'form-check-label' do
+      = f.check_box :admin, class: 'form-check-input'
+      | 管理者権限
+  .form-group
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control'
+  .form-group
+    = f.label :password_confirmation, 'パスワード(確認)'
+    = f.password_field :password_confirmation, class: 'form-control'
+  = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Users#edit
+p Find me in app/views/admin/users/edit.html.slim

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,2 +1,6 @@
-h1 Admin::Users#edit
-p Find me in app/views/admin/users/edit.html.slim
+h1 ユーザの編集
+
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+
+= render partial: 'form', locals: { user: @user }

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Users#index
+p Find me in app/views/admin/users/index.html.slim

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,2 +1,25 @@
-h1 Admin::Users#index
-p Find me in app/views/admin/users/index.html.slim
+h1 ユーザ一覧
+
+= link_to '新規登録', new_admin_user_path, class: 'btn btn-primary'
+
+.mb-3
+table.table.table-hover
+  thead.thead-default
+    tr
+      th= User.human_attribute_name(:name)
+      th= User.human_attribute_name(:email)
+      th= User.human_attribute_name(:admin)
+      th= User.human_attribute_name(:created_at)
+      th= User.human_attribute_name(:updated_at)
+      th
+  tbody
+    - @users.each do |user|
+      tr
+        td= link_to user.name, [:admin, user]
+        td= user.email
+        td= user.admin? ? 'あり' : 'なし'
+        td= user.created_at
+        td= user.updated_at
+        td
+          = link_to '編集', edit_admin_user_path(user), class: 'btn btn-primary mr-3'
+          = link_to '削除', [:admin, user], data: { turbo_method: :delete, turbo_confirm: "ユーザ「#{user.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,20 +1,6 @@
 h1  ユーザ登録
 
-= form_with model: [:admin, @user], local: true do |f|
-  .form-group
-    = f.label :name, '名前'
-    = f.text_field :name, class: 'form-control'
-  .form-group
-    = f.label :email, 'メールアドレス'
-    = f.text_field :email, class: 'form-control'
-  .form-check
-    = f.label :admin, class: 'form-check-label' do
-      = f.check_box :admin, class: 'form-check-input'
-      | 管理者権限
-  .form-group
-    = f.label :password, 'パスワード'
-    = f.password_field :password, class: 'form-control'
-  .form-group
-    = f.label :password_confirmation, 'パスワード(確認)'
-    = f.password_field :password_confirmation, class: 'form-control'
-  = f.submit '登録する', class: 'btn btn-primary'
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+
+= render partial: 'form', locals: { user: @user }

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,0 +1,20 @@
+h1  ユーザ登録
+
+= form_with model: [:admin, @user], local: true do |f|
+  .form-group
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .form-group
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control'
+  .form-check
+    = f.label :admin, class: 'form-check-label' do
+      = f.check_box :admin, class: 'form-check-input'
+      | 管理者権限
+  .form-group
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control'
+  .form-group
+    = f.label :password_confirmation, 'パスワード(確認)'
+    = f.password_field :password_confirmation, class: 'form-control'
+  = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Users#show
+p Find me in app/views/admin/users/show.html.slim

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,2 +1,27 @@
-h1 Admin::Users#show
-p Find me in app/views/admin/users/show.html.slim
+h1 ユーザの詳細
+
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+table.table.table-hover
+  tbody
+    tr
+      th= User.human_attribute_name(:id)
+      td= @user.id
+    tr
+      th= User.human_attribute_name(:name)
+      td= @user.name
+    tr
+      th= User.human_attribute_name(:email)
+      td= @user.email
+    tr
+      th= User.human_attribute_name(:admin)
+      td= @user.admin? ? 'あり' : 'なし'
+    tr
+      th= User.human_attribute_name(:created_at)
+      td= @user.created_at
+    tr
+      th= User.human_attribute_name(:updated_at)
+      td= @user.updated_at
+
+= link_to '編集', edit_admin_user_path, class: 'btn btn-primary mr-3'
+= link_to '削除', [:admin, @user], data: { turbo_method: :delete, turbo_confirm: "ユーザ「#{@user.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,7 +15,8 @@ html
       ul.navbar-nav.ml-auto
         - if current_user
           li.nav-item= link_to 'タスク一覧', tasks_path, class: 'nav-link'
-          li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
+          - if current_user.admin?
+            li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
           li.nav-item= link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link'
         - else
           li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -17,7 +17,7 @@ html
           li.nav-item= link_to 'タスク一覧', tasks_path, class: 'nav-link'
           - if current_user.admin?
             li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
-          li.nav-item= link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link'
+          li.nav-item= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'nav-link'
         - else
           li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'
     .container

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,6 +9,16 @@ html
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_importmap_tags
   body
+    .app-title.navbar.navbar-expand-md.navbar-light.bg-light
+      .navbar-brand Taskleaf
+
+      ul.navbar-nav.ml-auto
+        - if current_user
+          li.nav-item= link_to 'タスク一覧', tasks_path, class: 'nav-link'
+          li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
+          li.nav-item= link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link'
+        - else
+          li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'
     .container
       - if flash.notice.present?
         .alert.alert-success= flash.notice

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,0 +1,10 @@
+h1 ログイン
+
+= form_with scope: :session, local: true do |f|
+  .form-group
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control', id: 'session_email'
+  .form-group
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control', id: 'session_password'
+  = f.submit 'ログインする', class: 'btn btn-primary'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,14 @@ ja:
         description: 詳しい説明
         created_at: 登録日時
         updated_at: 更新日時
+      user:
+        name: 名前
+        email: メールアドレス
+        admin: 管理者権限
+        password: パスワード
+        password_confirmation: パスワード(確認)
+        created_at: 登録日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :users
+  end
+
   root to: 'tasks#index'
   resources :tasks
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
+  delete '/login', to: 'sessions#destroy'
   namespace :admin do
     resources :users
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
   namespace :admin do
     resources :users
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@
 Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
-  delete '/login', to: 'sessions#destroy'
+  delete '/logout', to: 'sessions#destroy'
+
   namespace :admin do
     resources :users
   end

--- a/db/migrate/20231114072318_create_users.rb
+++ b/db/migrate/20231114072318_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUsers < ActiveRecord::Migration[7.1]
   def change
     create_table :users do |t|

--- a/db/migrate/20231114072318_create_users.rb
+++ b/db/migrate/20231114072318_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+      t.index :email, unique: true
+    end
+  end
+end

--- a/db/migrate/20231114074613_add_admin_to_users.rb
+++ b/db/migrate/20231114074613_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20231114074613_add_admin_to_users.rb
+++ b/db/migrate/20231114074613_add_admin_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAdminToUsers < ActiveRecord::Migration[7.1]
   def change
     add_column :users, :admin, :boolean, default: false, null: false

--- a/db/migrate/20231115050606_add_user_id_to_tasks.rb
+++ b/db/migrate/20231115050606_add_user_id_to_tasks.rb
@@ -1,0 +1,10 @@
+class AddUserIdToTasks < ActiveRecord::Migration[7.1]
+  def up
+    execute 'DELETE FROM tasks;'
+    add_reference :tasks, :user, null: false, index: true
+  end
+
+  def down
+    remove_reference :tasks, :user, index: true
+  end
+end

--- a/db/migrate/20231115050606_add_user_id_to_tasks.rb
+++ b/db/migrate/20231115050606_add_user_id_to_tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUserIdToTasks < ActiveRecord::Migration[7.1]
   def up
     execute 'DELETE FROM tasks;'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_14_072318) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_14_074613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_14_072318) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,27 +12,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_15_050606) do
+ActiveRecord::Schema[7.1].define(version: 20_231_115_050_606) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "tasks", force: :cascade do |t|
-    t.string "name"
-    t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.index ["user_id"], name: "index_tasks_on_user_id"
+  create_table 'tasks', force: :cascade do |t|
+    t.string 'name'
+    t.text 'description'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.bigint 'user_id', null: false
+    t.index ['user_id'], name: 'index_tasks_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "email", null: false
-    t.string "password_digest", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "admin", default: false, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'name', null: false
+    t.string 'email', null: false
+    t.string 'password_digest', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.boolean 'admin', default: false, null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_14_074613) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_15_050606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_14_074613) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,14 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_231_113_011_826) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_14_072318) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'tasks', force: :cascade do |t|
-    t.string 'name'
-    t.text 'description'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "tasks", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get admin_users_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get admin_users_edit_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get admin_users_show_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get admin_users_index_url
+    assert_response :success
+  end
+end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,23 +1,27 @@
-require "test_helper"
+# frozen_string_literal: true
 
-class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
-    get admin_users_new_url
-    assert_response :success
-  end
+require 'test_helper'
 
-  test "should get edit" do
-    get admin_users_edit_url
-    assert_response :success
-  end
+module Admin
+  class UsersControllerTest < ActionDispatch::IntegrationTest
+    test 'should get new' do
+      get admin_users_new_url
+      assert_response :success
+    end
 
-  test "should get show" do
-    get admin_users_show_url
-    assert_response :success
-  end
+    test 'should get edit' do
+      get admin_users_edit_url
+      assert_response :success
+    end
 
-  test "should get index" do
-    get admin_users_index_url
-    assert_response :success
+    test 'should get show' do
+      get admin_users_show_url
+      assert_response :success
+    end
+
+    test 'should get index' do
+      get admin_users_index_url
+      assert_response :success
+    end
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get sessions_new_url
+    assert_response :success
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,7 +1,9 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class SessionsControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
+  test 'should get new' do
     get sessions_new_url
     assert_response :success
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  email: MyString
+  password_digest: MyString
+
+two:
+  name: MyString
+  email: MyString
+  password_digest: MyString

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
レビュー⑧ 4-5-10~ ログインユーザーのみ操作可能などの機能制限
が完了しましたので、ご確認よろしくお願いいたします。

## 実施したこと
・前章の最後に実施したコールバックの処理を削除(テキストの指示)
・userモデル、sessionモデル作成
・ユーザー登録
・ユーザーログイン/ログアウト
・非ログインユーザーへの制限
・ユーザー登録(管理者のみ登録可能)
・ユーザー一覧(管理者のみ閲覧可能)

## テキストと異なる点
### ・admin/users_controller.rb、tasks_controller.rb
バリデーションエラー表示の際、`render :new`で返すときに `status: :unprocessable_entity`を付与するように変更。
```Ruby
  def create
    ....
    if user&.authenticate(session_params[:password])
      ....
    else
      render :new, status: :unprocessable_entity
    end
  end
```
### ・admin/users/index.html.slim、admin/users/show.html.slim、<br>application.html.slim
以下例のように、data-method:をdata-turbo_methodに変更
例（application.html.slim）：
テキスト
```
li.nav-item= link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link'
```
修正後
```
li.nav-item= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'nav-link'
```

## rubocopについて
自動生成されるファイルについて、rubocopの監視対象から外すため、
新たにdb/以下のファイルをexclude設定しました。
```
# .rubocop.yml
 Exclude:
   - "config/**/*"
   - "bin/*"
   - "db/**/*"
```

## 実行結果
・ユーザーログイン/ログアウト
[![Image from Gyazo](https://i.gyazo.com/9bf54dfdf3f346364a4353f93bd51b05.gif)](https://gyazo.com/9bf54dfdf3f346364a4353f93bd51b05)

・非ログインユーザーへの制限
　ログアウト状態でタスク一覧のページへ遷移しようとしたら
　ログインページへ戻される
[![Image from Gyazo](https://i.gyazo.com/af7741259910dfc49377c51bb57d3c19.gif)](https://gyazo.com/af7741259910dfc49377c51bb57d3c19)

・ユーザー一覧(管理者のみ閲覧可能)
　①管理者
![image](https://github.com/ChisatoMatoba/taskleaf_matoba/assets/149556430/6a3fb57d-3134-4ef0-8ad6-02f5f8a0ee23)

　②非管理者(ユーザー一覧が見れない)
![image](https://github.com/ChisatoMatoba/taskleaf_matoba/assets/149556430/3f012a45-b881-4fc6-837d-96ca76d47026)

・ユーザー登録(管理者のみ登録可能)
[![Image from Gyazo](https://i.gyazo.com/799c9eedfb301aed5355938534bd8a58.gif)](https://gyazo.com/799c9eedfb301aed5355938534bd8a58)